### PR TITLE
fix: checks for policy id in results

### DIFF
--- a/cmd/opa-plugin/server/composer.go
+++ b/cmd/opa-plugin/server/composer.go
@@ -83,7 +83,7 @@ func (c *Composer) GeneratePolicySet(pl policy.Policy) error {
 		return err
 	}
 
-	configFileName := filepath.Join(outputDir, "config.json")
+	configFileName := filepath.Join(outputDir, "data.json")
 	if err := os.WriteFile(configFileName, policyConfigData, 0644); err != nil {
 		return fmt.Errorf("failed to write policy config to %s: %w", configFileName, err)
 	}

--- a/cmd/opa-plugin/server/composer.go
+++ b/cmd/opa-plugin/server/composer.go
@@ -58,18 +58,16 @@ func (c *Composer) Bundle(ctx context.Context, config Config) error {
 }
 
 func (c *Composer) GeneratePolicySet(pl policy.Policy) error {
-	policyConfig := map[string]map[string]string{}
+	parameterMap := map[string]string{}
 	outputDir := c.policyOutput
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
 	}
 
 	for _, rule := range pl {
-		parameterMap := make(map[string]string)
 		for _, prm := range rule.Rule.Parameters {
 			parameterMap[prm.ID] = prm.Value
 		}
-		policyConfig[rule.Rule.ID] = parameterMap
 		// Copy over in-scope policies checks for the assessment
 		for _, check := range rule.Checks {
 			origfilePath := filepath.Join(c.policiesTemplates, fmt.Sprintf("%s.rego", check.ID))
@@ -80,7 +78,7 @@ func (c *Composer) GeneratePolicySet(pl policy.Policy) error {
 		}
 	}
 
-	policyConfigData, err := json.MarshalIndent(policyConfig, "", " ")
+	policyConfigData, err := json.MarshalIndent(parameterMap, "", " ")
 	if err != nil {
 		return err
 	}

--- a/cmd/opa-plugin/server/loader.go
+++ b/cmd/opa-plugin/server/loader.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Loader struct {
+	policyIndex map[string][]NormalizedOPAResult
+}
+
+func NewLoader() *Loader {
+	return &Loader{
+		policyIndex: make(map[string][]NormalizedOPAResult),
+	}
+}
+
+func (fl *Loader) LoadFromDirectory(dir string) error {
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && (strings.HasSuffix(info.Name(), ".json")) {
+			file, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			var opaResult output
+			if err := json.Unmarshal(file, &opaResult); err != nil {
+				return fmt.Errorf("failed to unmarshal opa results for %s: %w", info.Name(), err)
+			}
+
+			normalizedOPAResults := NormalizeOPAResult(opaResult.Result)
+			for _, normalizedOPAResult := range normalizedOPAResults {
+				// fallback to the filename
+				policyId := strings.TrimSuffix(info.Name(), ".json")
+				if normalizedOPAResult.PolicyId != "" {
+					policyId = normalizedOPAResult.PolicyId
+				}
+				results, ok := fl.policyIndex[policyId]
+				if !ok {
+					results = []NormalizedOPAResult{}
+				}
+				results = append(results, normalizedOPAResult)
+				fl.policyIndex[policyId] = results
+			}
+
+		}
+		return nil
+	}
+
+	err := filepath.Walk(dir, walkFn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (fl *Loader) ResultsByPolicyId(policyId string) []NormalizedOPAResult {
+	results := fl.policyIndex[policyId]
+	return results
+}

--- a/cmd/opa-plugin/server/result.go
+++ b/cmd/opa-plugin/server/result.go
@@ -19,6 +19,7 @@ type output struct {
 // from any OPA policy decision.
 type NormalizedOPAResult struct {
 	Allowed         bool     `json:"allowed"`
+	PolicyId        string   `json:"policy_id"`
 	Reason          string   `json:"reason,omitempty"`
 	Violations      []string `json:"violations,omitempty"`
 	Recommendations []string `json:"recommendations,omitempty"` // Example: for audit policies
@@ -55,6 +56,10 @@ func NormalizeOPAResult(rawResult rego.ResultSet) []NormalizedOPAResult {
 					} else {
 						normalized.Reason = "Policy explicitly denied access."
 					}
+				}
+
+				if policyId, ok := value["policy_id"].(string); ok {
+					normalized.PolicyId = policyId
 				}
 
 				if violations, ok := value["violation"].(map[string]interface{}); ok {

--- a/cmd/opa-plugin/server/result_test.go
+++ b/cmd/opa-plugin/server/result_test.go
@@ -18,6 +18,7 @@ func Test_NormalizedOPAResults(t *testing.T) {
             "evaluation_resource_id": "github.com/example/demo@main",
             "evaluation_resource_name": "github.com/example/demo@main",
             "evaluation_resource_type": "resource",
+            "policy_id": "my-policy",
             "has_pull_request_rule": true,
             "main_branch_min_approvals": "1",
             "violation": {
@@ -42,6 +43,7 @@ func Test_NormalizedOPAResults(t *testing.T) {
 	expectedResults := []NormalizedOPAResult{
 		{
 			Allowed:               false,
+			PolicyId:              "my-policy",
 			Reason:                "Policy denied due to violations.",
 			EvaluatedResourceType: "resource",
 			EvaluatedResourceID:   "github.com/example/demo@main",


### PR DESCRIPTION
To reduce brittleness for check mapping, the
policy id is determine by the result metadata and falls back to the file if the field does not exist

Closes #3 